### PR TITLE
Various improvements

### DIFF
--- a/lib/puppet/parser/functions/sorted_json.rb
+++ b/lib/puppet/parser/functions/sorted_json.rb
@@ -1,0 +1,41 @@
+require 'json'
+
+def sorted_json(obj)
+  case obj
+    when String, Fixnum, Float, TrueClass, FalseClass, NilClass
+      return obj.to_json
+    when Array
+      arrayRet = []
+      obj.each do |a|
+        arrayRet.push(sorted_json(a))
+      end
+      return "[" << arrayRet.join(',') << "]";
+    when Hash
+      ret = []
+      obj.keys.sort.each do |k|
+        ret.push(k.to_json << ":" << sorted_json(obj[k]))
+      end
+      return "{" << ret.join(",") << "}";
+    else
+      raise Exception("Unable to handle object of type <%s>" % obj.class.to_s)
+  end
+end
+
+module Puppet::Parser::Functions
+  newfunction(:sorted_json, :type => :rvalue, :doc => <<-EOS
+This function takes data, outputs making sure the hash keys are sorted
+
+*Examples:*
+
+    sorted_json({'key'=>'value'})
+
+Would return: {'key':'value'}
+    EOS
+  ) do |arguments|
+    raise(Puppet::ParseError, "sorted_json(): Wrong number of arguments " +
+      "given (#{arguments.size} for 1)") if arguments.size != 1
+
+    json = arguments[0]
+    return sorted_json(json)
+  end
+end

--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -1,22 +1,15 @@
-# It is a bit messy because of the use of eval but the idea is there:
-# * `dbus-launch --auto-syntax` sets some environment vars
-# * `dconf write` writes the conf
-#
-# Note: `value` needs to be escaped in a non-intuitive way. See the examples in the README.
-
 define dconf::set ($value,$user,$group) {
 	include dconf
 
 	debug "Dconf: set $name to $value for user $user and group $group"
 
-	exec { "dconf set $name":
-		command => "/bin/sh -c 'eval `dbus-launch --auto-syntax`'\" && dconf write $name \\\"$value\\\"\"",
-		path => "/usr/bin",
-		onlyif => "/bin/sh -c 'eval `dbus-launch --auto-syntax`'\" && test \\\"$value\\\" != \\\"`dconf read $name`\\\"\"",
-		logoutput => "true",
-		require => Package['dconf-tools'],
-		user => $user,
-		group => $group,
-		environment => "XDG_RUNTIME_DIR=/run/user/$user",
-	}
+  exec { "dconf set $name outside user session":
+    command   => shellquote('dbus-launch', '--exit-with-session', 'dconf', 'write', $name, sorted_json($value)),
+    path      => "/usr/bin",
+    logoutput => "true",
+    provider  => 'shell',
+    require   => Package['dconf-tools'],
+    user      => $user,
+    group     => $group,
+  }
 }

--- a/manifests/set.pp
+++ b/manifests/set.pp
@@ -11,5 +11,17 @@ define dconf::set ($value,$user,$group) {
     require   => Package['dconf-tools'],
     user      => $user,
     group     => $group,
+    onlyif    => 'test -z "$DBUS_SESSION_BUS_ADDRESS"',
+  }
+
+  exec { "dconf set $name inside user session":
+    command   => shellquote('dconf', 'write', $name, sorted_json($value)),
+    path      => "/usr/bin:/bin",
+    logoutput => "true",
+    provider  => 'shell',
+    require   => Package['dconf-tools'],
+    user      => $user,
+    group     => $group,
+    onlyif    => 'test -n "$DBUS_SESSION_BUS_ADDRESS"',
   }
 }


### PR DESCRIPTION
I made the following improvements to `puppet-dconf`:

* Value can be a list or a map and it is automatically converted into JSON;
* More robust shell quoting;
* Re-use existing DBUS.

The later is useful if puppet it used to manage user settings from Unity and you want certain settings to be shown immediately, through `dconf` notification:

    sudo \
         DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS \
         puppet apply --modulepath=modules environments/default.pp

See https://github.com/cristiklein/puppet-developer-laptop/blob/master/modules/default-apps-user-config/manifests/init.pp for an example.